### PR TITLE
Update payout formula

### DIFF
--- a/config/grain.json
+++ b/config/grain.json
@@ -1,5 +1,7 @@
 {
-  "immediatePerWeek": 1000,
-  "balancedPerWeek": 4000,
+  "immediatePerWeek": 0,
+  "balancedPerWeek": 1250,
+  "recentPerWeek": 3750,
+  "recentWeeklyDecayRate": 0.4,
   "maxSimultaneousDistributions": 100
 }


### PR DESCRIPTION
Updated `grain.json` for new payout formula: 25% Balanced (balancedPerWeek), 75% Recent (recentPerWeek) with 0.4 decay rate. 

