### PR TITLE
Add package.json to gh-pages branch so you can checkout and serve

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           yarn site
           rm -rf ./site/{output,data,config,sourcecred.json}
-          cp -r ./{output,data,config,sourcecred.json} ./site/
+          cp -r ./{output,data,config,sourcecred.json,package.json} ./site/
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.0.0


### PR DESCRIPTION
Paired with @blueridger

Adding package.json to gh-pages branch so you can checkout and serve gh-pages locally. This allows you to play with prod scores/graphs without having to run load. Further details can be found in this [PR on sourcecred/cred](https://github.com/sourcecred/cred/pull/247). 



