### PR TITLE
Rollback sourcecred version to v.0.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "sourcecred": "^0.8.0"
+    "sourcecred": "^0.7.7"
   },
   "scripts": {
     "clean": "rimraf cache site",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2741,10 +2741,10 @@ source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sourcecred@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/sourcecred/-/sourcecred-0.8.0.tgz#9117ac32ea96eab739e9d8d12405eb0148a508de"
-  integrity sha512-hT5bdxc4UfhZh/4tXrA0yS5LCCvySuvF3eHNvisUltVbi4jGXrnsKsXDEZzDUp0Kbr4l6Tuod35RrAQpqEap+w==
+sourcecred@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/sourcecred/-/sourcecred-0.7.7.tgz#f7ea11cf823bef031fb24a905133d5aa75430b9e"
+  integrity sha512-p6eZuR6vjBpE1Fj15cXW8Z6oMgCxJa7H/THnkgTTLbNuZ4VGx8s3O0HgodQawnHsU/eLtSC8sonpNiR6psjIgA==
   dependencies:
     "@material-ui/lab" "^4.0.0-alpha.56"
     aphrodite "^2.4.0"


### PR DESCRIPTION
Rolling back sourcecred version to 0.7.7 due to display error on the Explorer Home page that was causing Cred scores to not be visible. 