### PR TITLE
Fix: Update generate Instance to Utilize Credrank

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -25,16 +25,11 @@ jobs:
       - name: Install Packages 🔧
         run: yarn --frozen-lockfile
 
-      - name: Load Data into Graph 🔌
-        run: |
-          yarn load
-          yarn graph
+      - name: Load Data and Compute Cred 🧮
+        run: yarn sourcecred go
         env:
           SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
-
-      - name: Compute Cred 🧮
-        run: yarn score
 
       - name: Generate Frontend 🏗
         run: |


### PR DESCRIPTION
`score` is deprecated, so we'll migrate the action to the `go` command, which calls `credrank` under the hood.

This is consistent with the more up-to-date template-instance: 
https://github.com/sourcecred/template-instance/blob/master/.github/workflows/generate-instance.yml